### PR TITLE
Patch delete api calls

### DIFF
--- a/src/utils/apiCalls/apiCalls.js
+++ b/src/utils/apiCalls/apiCalls.js
@@ -6,7 +6,7 @@ export const getAllProjects = async () => {
     throw new Error('Could not retrieve projects, please try again later.');
   }
   const data = await response.json();
-console.log('in getAllProjects')
+
   return data;
 };
 
@@ -94,38 +94,6 @@ export const createNewPalette = async palette => {
   return data;
 };
 
-export const updateProjectName = async id => {
-  const options = {
-    method: 'PATCH',
-    body: JSON.stringify({
-      completed: true
-    }),
-    headers: {
-      'Content-type': 'application/json'
-    }
-  }
-  const response = await fetch(`${process.env.REACT_APP_PRODUCTION_URL}/api/v1/projects/${id}`, options);
-  const data = response.json();
-
-  return data;
-}
-
-export const updatePalette = async id => {
-  const options = {
-    method: 'PATCH',
-    body: JSON.stringify({
-      completed: true
-    }),
-    headers: {
-      'Content-type': 'application/json'
-    }
-  }
-  const response = await fetch(`${process.env.REACT_APP_PRODUCTION_URL}/api/v1/palette/${id}`, options);
-  const data = response.json();
-
-  return data;
-}
-
 export const deleteProject = async id => {
   const options = {
     method: 'DELETE',
@@ -133,10 +101,10 @@ export const deleteProject = async id => {
       'Content-Type': 'application/json'
     }
   }
-
+  
   const response = await fetch(`${process.env.REACT_APP_PRODUCTION_URL}/api/v1/projects/${id}`, options)
   const data = response.json();
-
+  
   return data;
 }
 
@@ -147,9 +115,41 @@ export const deletePalette = async id => {
       'Content-Type': 'application/json'
     }
   }
-
+  
   const response = await fetch(`${process.env.REACT_APP_PRODUCTION_URL}/api/v1/palette/${id}`, options)
   const data = response.json();
-
+  
   return data;
 }
+
+// export const updateProjectName = async id => {
+//   const options = {
+//     method: 'PATCH',
+//     body: JSON.stringify({
+//       completed: true
+//     }),
+//     headers: {
+//       'Content-type': 'application/json'
+//     }
+//   }
+//   const response = await fetch(`${process.env.REACT_APP_PRODUCTION_URL}/api/v1/projects/${id}`, options);
+//   const data = response.json();
+
+//   return data;
+// }
+
+// export const updatePalette = async id => {
+//   const options = {
+//     method: 'PATCH',
+//     body: JSON.stringify({
+//       completed: true
+//     }),
+//     headers: {
+//       'Content-type': 'application/json'
+//     }
+//   }
+//   const response = await fetch(`${process.env.REACT_APP_PRODUCTION_URL}/api/v1/palette/${id}`, options);
+//   const data = response.json();
+
+//   return data;
+// }

--- a/src/utils/apiCalls/apiCalls.js
+++ b/src/utils/apiCalls/apiCalls.js
@@ -69,7 +69,7 @@ export const createNewProject = async project => {
     }
   };
   const response = await fetch(
-    `${process.env.REACT_APP_PRODUCTION_URL}/api/v1/projects}`,
+    `${process.env.REACT_APP_PRODUCTION_URL}/api/v1/projects`,
     options
   );
   const data = await response.json();

--- a/src/utils/apiCalls/apiCalls.js
+++ b/src/utils/apiCalls/apiCalls.js
@@ -121,35 +121,3 @@ export const deletePalette = async id => {
   
   return data;
 }
-
-// export const updateProjectName = async id => {
-//   const options = {
-//     method: 'PATCH',
-//     body: JSON.stringify({
-//       completed: true
-//     }),
-//     headers: {
-//       'Content-type': 'application/json'
-//     }
-//   }
-//   const response = await fetch(`${process.env.REACT_APP_PRODUCTION_URL}/api/v1/projects/${id}`, options);
-//   const data = response.json();
-
-//   return data;
-// }
-
-// export const updatePalette = async id => {
-//   const options = {
-//     method: 'PATCH',
-//     body: JSON.stringify({
-//       completed: true
-//     }),
-//     headers: {
-//       'Content-type': 'application/json'
-//     }
-//   }
-//   const response = await fetch(`${process.env.REACT_APP_PRODUCTION_URL}/api/v1/palette/${id}`, options);
-//   const data = response.json();
-
-//   return data;
-// }

--- a/src/utils/apiCalls/apiCalls.js
+++ b/src/utils/apiCalls/apiCalls.js
@@ -1,5 +1,3 @@
-// require('dotenv').config();
-
 export const getAllProjects = async () => {
   const response = await fetch(
     `${process.env.REACT_APP_PRODUCTION_URL}/api/v1/projects`
@@ -8,6 +6,7 @@ export const getAllProjects = async () => {
     throw new Error('Could not retrieve projects, please try again later.');
   }
   const data = await response.json();
+
   return data;
 };
 
@@ -19,6 +18,7 @@ export const getAllPalettes = async () => {
     throw new Error('Could not retrieve palettes, please try again later.');
   }
   const data = await response.json();
+
   return data;
 };
 
@@ -30,6 +30,7 @@ export const getProject = async id => {
     throw new Error('Could not retrieve project, please try again later.');
   }
   const data = await response.json();
+
   return data;
 };
 
@@ -43,6 +44,7 @@ export const getPalettesInProject = async id => {
     );
   }
   const data = await response.json();
+
   return data;
 };
 
@@ -54,6 +56,7 @@ export const getPalette = async id => {
     throw new Error('Could not retrieve palette, please try again later.');
   }
   const data = await response.json();
+
   return data;
 };
 
@@ -70,6 +73,7 @@ export const createNewProject = async project => {
     options
   );
   const data = await response.json();
+
   return data;
 };
 
@@ -86,5 +90,34 @@ export const createNewPalette = async palette => {
     options
   );
   const data = await response.json();
+
   return data;
 };
+
+export const deleteProject = async id => {
+  const options = {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  }
+
+  const response = await fetch(`${process.env.REACT_APP_PRODUCTION_URL}/api/v1/projects/${id}`, options)
+  const data = response.json();
+
+  return data;
+}
+
+export const deletePalette = async id => {
+  const options = {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  }
+
+  const response = await fetch(`${process.env.REACT_APP_PRODUCTION_URL}/api/v1/palette/${id}`, options)
+  const data = response.json();
+
+  return data;
+}

--- a/src/utils/apiCalls/apiCalls.js
+++ b/src/utils/apiCalls/apiCalls.js
@@ -6,7 +6,7 @@ export const getAllProjects = async () => {
     throw new Error('Could not retrieve projects, please try again later.');
   }
   const data = await response.json();
-
+console.log('in getAllProjects')
   return data;
 };
 
@@ -93,6 +93,38 @@ export const createNewPalette = async palette => {
 
   return data;
 };
+
+export const updateProjectName = async id => {
+  const options = {
+    method: 'PATCH',
+    body: JSON.stringify({
+      completed: true
+    }),
+    headers: {
+      'Content-type': 'application/json'
+    }
+  }
+  const response = await fetch(`${process.env.REACT_APP_PRODUCTION_URL}/api/v1/projects/${id}`, options);
+  const data = response.json();
+
+  return data;
+}
+
+export const updatePalette = async id => {
+  const options = {
+    method: 'PATCH',
+    body: JSON.stringify({
+      completed: true
+    }),
+    headers: {
+      'Content-type': 'application/json'
+    }
+  }
+  const response = await fetch(`${process.env.REACT_APP_PRODUCTION_URL}/api/v1/palette/${id}`, options);
+  const data = response.json();
+
+  return data;
+}
 
 export const deleteProject = async id => {
   const options = {

--- a/src/utils/apiCalls/apiCalls.test.js
+++ b/src/utils/apiCalls/apiCalls.test.js
@@ -46,8 +46,6 @@ describe('getAllProjects', () => {
   });
 });
 
-
-// ALL PALETTES
 describe('getAllPalettes', () => {
   const mockResponse = [
     {
@@ -101,7 +99,7 @@ describe('getAllPalettes', () => {
 });
 
 describe('createNewProject', () => {
-  const mockResponse = { id: 7}
+  const mockResponse = { id: 7 };
 
   beforeEach(() => {
     window.fetch = jest.fn().mockImplementation(() => {
@@ -123,9 +121,9 @@ describe('createNewProject', () => {
       headers: {
         'Content-Type': 'application/json'
       }
-    }
+    };
 
-    createNewProject(newProject)
+    createNewProject(newProject);
 
     expect(window.fetch).toHaveBeenCalledWith(url, options);
   });
@@ -152,7 +150,7 @@ describe('createNewProject', () => {
 });
 
 describe('createNewPalette', () => {
-  const mockResponse = { id: 7}
+  const mockResponse = { id: 7 };
 
   beforeEach(() => {
     window.fetch = jest.fn().mockImplementation(() => {
@@ -212,15 +210,13 @@ describe('createNewPalette', () => {
 });
 
 describe('deleteProject', () => {
-  beforeEach(() => {
+  it ('should be called with the correct arguments', () => {
     window.fetch = jest.fn().mockImplementation(() => {
       return Promise.resolve({
         ok: true
       });
     });
-  });
 
-  it('should be called with the correct arguments', () => {
     const projectToDelete = { project_name: 'A Project', id: 8 };
   
     const url = `${baseUrl}/api/v1/projects/${projectToDelete.id}`;
@@ -235,6 +231,19 @@ describe('deleteProject', () => {
     deleteProject(projectToDelete.id)
 
     expect(window.fetch).toHaveBeenCalledWith(url, options);
+  });
+
+  it ('should return an error with an unsuccessful delete', () => {
+    window.fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: false,
+        statusText: "Error. Please try again."
+      })
+    });
+
+    const url = `${baseUrl}/api/v1/projects/-1`;
+
+    expect(deleteProject(url)).rejects.toEqual(Error('Error. Please try again.'))
   });
 });
 
@@ -271,6 +280,19 @@ describe('deletePalette', () => {
     deletePalette(paletteToDelete.id)
 
     expect(window.fetch).toHaveBeenCalledWith(url, options);
+  });
+
+  it ('should return an error with an unsuccessful delete', () => {
+    window.fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: false,
+        statusText: "Error. Please try again."
+      })
+    });
+
+    const url = `${baseUrl}/api/v1/palettes/-1`;
+
+    expect(deletePalette(url)).rejects.toEqual(Error('Error. Please try again.'))
   });
 });
 

--- a/src/utils/apiCalls/apiCalls.test.js
+++ b/src/utils/apiCalls/apiCalls.test.js
@@ -5,7 +5,8 @@ import {
   getPalettesInProject,
   getPalette,
   createNewProject,
-  createNewPalette
+  createNewPalette,
+  deleteProject,
 } from './apiCalls';
 
 const baseUrl = 'https://vr-je-palette-picker-api.herokuapp.com'
@@ -115,7 +116,7 @@ describe('createNewProject', () => {
   
     const url = `${baseUrl}/api/v1/projects`;
 
-    const expected = {
+    const options = {
       method: 'POST',
       body: JSON.stringify(newProject),
       headers: {
@@ -125,7 +126,7 @@ describe('createNewProject', () => {
 
     createNewProject(newProject)
 
-    expect(window.fetch).toHaveBeenCalledWith(url, expected);
+    expect(window.fetch).toHaveBeenCalledWith(url, options);
   });
 
   it ('should post a new project', () => {
@@ -207,7 +208,34 @@ describe('createNewPalette', () => {
 
     expect(createNewPalette(url)).rejects.toEqual(Error("Error. Please try again."));
   });
-})
+});
+
+describe('deleteProject', () => {
+  beforeEach(() => {
+    window.fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: true
+      });
+    });
+  });
+
+  it('should be called with the correct arguments', () => {
+    const projectToDelete = { project_name: 'A Project', id: 8 };
+  
+    const url = `${baseUrl}/api/v1/projects/${projectToDelete.id}`;
+
+    const options = {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+
+    deleteProject(projectToDelete.id)
+
+    expect(window.fetch).toHaveBeenCalledWith(url, options);
+  });
+});
 
 
 // A SINGLE PROJECT

--- a/src/utils/apiCalls/apiCalls.test.js
+++ b/src/utils/apiCalls/apiCalls.test.js
@@ -7,6 +7,7 @@ import {
   createNewProject,
   createNewPalette,
   deleteProject,
+  deletePalette
 } from './apiCalls';
 
 const baseUrl = 'https://vr-je-palette-picker-api.herokuapp.com'
@@ -237,7 +238,45 @@ describe('deleteProject', () => {
   });
 });
 
+describe('deletePalette', () => {
+  beforeEach(() => {
+    window.fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: true
+      });
+    });
+  });
 
+  it('should be called with the correct arguments', () => {
+    const paletteToDelete = {
+          id: 1,
+          palette_name: "Option 1",
+          color_1: "#192435",
+          color_2: "#678589",
+          color_3: "#77ACA2",
+          color_4: "#EDF3F3",
+          color_5: "#C59563",
+          prect_id: 1
+      };
+  
+    const url = `${baseUrl}/api/v1/palette/${paletteToDelete.id}`;
+
+    const options = {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+
+    deletePalette(paletteToDelete.id)
+
+    expect(window.fetch).toHaveBeenCalledWith(url, options);
+  });
+});
+
+
+
+//************************************ */
 // A SINGLE PROJECT
 // describe('getProject', () => {
 //   const mockResponse = {

--- a/src/utils/apiCalls/apiCalls.test.js
+++ b/src/utils/apiCalls/apiCalls.test.js
@@ -135,6 +135,20 @@ describe('createNewProject', () => {
     .then(results => expect(results).toEqual(mockResponse.id))
   });
 
+  it('should return an error with unsuccessful post', () => {
+    window.fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: false,
+        statusText: "Error. Please try again."
+      })
+    });
+
+
+    const url = `${baseUrl}/api/v1/projects`;
+
+    expect(createNewProject(url)).rejects.toEqual(Error("Error. Please try again."));
+  })
+
 });
 
 

--- a/src/utils/apiCalls/apiCalls.test.js
+++ b/src/utils/apiCalls/apiCalls.test.js
@@ -128,6 +128,13 @@ describe('createNewProject', () => {
     expect(window.fetch).toHaveBeenCalledWith(url, expected);
   });
 
+  it ('should post a new project', () => {
+    const url = `${baseUrl}/api/v1/projects`;
+
+    createNewProject(url)
+    .then(results => expect(results).toEqual(mockResponse.id))
+  });
+
 });
 
 

--- a/src/utils/apiCalls/apiCalls.test.js
+++ b/src/utils/apiCalls/apiCalls.test.js
@@ -210,15 +210,18 @@ describe('createNewPalette', () => {
 });
 
 describe('deleteProject', () => {
-  it ('should be called with the correct arguments', () => {
+  let projectToDelete;
+  beforeEach(() => {
+    projectToDelete = { project_name: 'A Project', id: 8 };
+    
     window.fetch = jest.fn().mockImplementation(() => {
       return Promise.resolve({
-        ok: true
+        ok: true,
       });
     });
+  });
 
-    const projectToDelete = { project_name: 'A Project', id: 8 };
-  
+  it ('should be called with the correct arguments', () => {
     const url = `${baseUrl}/api/v1/projects/${projectToDelete.id}`;
 
     const options = {
@@ -231,6 +234,19 @@ describe('deleteProject', () => {
     deleteProject(projectToDelete.id)
 
     expect(window.fetch).toHaveBeenCalledWith(url, options);
+  });
+
+  it ('should delete project', () => {
+    const url = `${baseUrl}/api/v1/projects/${projectToDelete.id}`;
+    const options = {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    };
+
+    deleteProject(projectToDelete.id);
+    expect(window.fetch).toHaveBeenCalledWith(url, options)
   });
 
   it ('should return an error with an unsuccessful delete', () => {
@@ -282,6 +298,19 @@ describe('deletePalette', () => {
     expect(window.fetch).toHaveBeenCalledWith(url, options);
   });
 
+  it ('should delete palette', () => {
+    const url = `${baseUrl}/api/v1/palette/8`;
+    const options = {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    };
+
+    deletePalette(8);
+    expect(window.fetch).toHaveBeenCalledWith(url, options)
+  });
+
   it ('should return an error with an unsuccessful delete', () => {
     window.fetch = jest.fn().mockImplementation(() => {
       return Promise.resolve({
@@ -295,36 +324,3 @@ describe('deletePalette', () => {
     expect(deletePalette(url)).rejects.toEqual(Error('Error. Please try again.'))
   });
 });
-
-
-
-//************************************ */
-// A SINGLE PROJECT
-// describe('getProject', () => {
-//   const mockResponse = {
-//       id: 2,
-//       project_name: 'Nature',
-//       created_at: '2019-12-06T20:35:56.736Z',
-//       updated_at: '2019-12-06T20:35:56.736Z'
-//     }
-
-//   beforeEach(() => {
-//     window.fetch = jest.fn().mockImplementation(() => {
-//       return Promise.resolve({
-//         ok: true,
-//         json: () => Promise.resolve(mockResponse)
-//       });
-//     });
-//   });
-
-//   it ('should fetch with the correct url', () => {
-//     window.fetch.mockClear();
-//     const url = `${baseUrl}/api/v1/projects${mockResponse.id}`;
-    
-//     getProject(url);
-
-//     expect(window.fetch).toHaveBeenCalledWith(url);
-//   });
-// });
-
-

--- a/src/utils/apiCalls/apiCalls.test.js
+++ b/src/utils/apiCalls/apiCalls.test.js
@@ -161,32 +161,32 @@ describe('createNewPalette', () => {
     });
   });
 
-  // it ('should fetch with all of the correct arguments', () => {
-  //   const newPalette = {
-  //     id: 1,
-  //     palette_name: "Option 1",
-  //     color_1: "#192435",
-  //     color_2: "#678589",
-  //     color_3: "#77ACA2",
-  //     color_4: "#EDF3F3",
-  //     color_5: "#C59563",
-  //     prect_id: 1
-  // };
+  it ('should fetch with all of the correct arguments', () => {
+    const newPalette = {
+      id: 1,
+      palette_name: "Option 1",
+      color_1: "#192435",
+      color_2: "#678589",
+      color_3: "#77ACA2",
+      color_4: "#EDF3F3",
+      color_5: "#C59563",
+      project_id: 1
+  };
   
-  //   const url = `${baseUrl}/api/v1/palettes/1`;
+    const url = `${baseUrl}/api/v1/palettes/1`;
 
-  //   const expected = {
-  //     method: 'POST',
-  //     body: JSON.stringify(newPalette),
-  //     headers: {
-  //       'Content-Type': 'application/json'
-  //     }
-  //   }
+    const expected = {
+      method: 'POST',
+      body: JSON.stringify(newPalette),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
 
-  //   createNewPalette(newPalette)
+    createNewPalette(newPalette)
 
-  //   expect(window.fetch).toHaveBeenCalledWith(url, expected);
-  // });
+    expect(window.fetch).toHaveBeenCalledWith(url, expected);
+  });
 
   it ('should post a new project', () => {
     const url = `${baseUrl}/api/v1/projects/1`;

--- a/src/utils/apiCalls/apiCalls.test.js
+++ b/src/utils/apiCalls/apiCalls.test.js
@@ -143,13 +143,71 @@ describe('createNewProject', () => {
       })
     });
 
-
     const url = `${baseUrl}/api/v1/projects`;
 
     expect(createNewProject(url)).rejects.toEqual(Error("Error. Please try again."));
-  })
-
+  });
 });
+
+describe('createNewPalette', () => {
+  const mockResponse = { id: 7}
+
+  beforeEach(() => {
+    window.fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockResponse.id)
+      });
+    });
+  });
+
+  // it ('should fetch with all of the correct arguments', () => {
+  //   const newPalette = {
+  //     id: 1,
+  //     palette_name: "Option 1",
+  //     color_1: "#192435",
+  //     color_2: "#678589",
+  //     color_3: "#77ACA2",
+  //     color_4: "#EDF3F3",
+  //     color_5: "#C59563",
+  //     prect_id: 1
+  // };
+  
+  //   const url = `${baseUrl}/api/v1/palettes/1`;
+
+  //   const expected = {
+  //     method: 'POST',
+  //     body: JSON.stringify(newPalette),
+  //     headers: {
+  //       'Content-Type': 'application/json'
+  //     }
+  //   }
+
+  //   createNewPalette(newPalette)
+
+  //   expect(window.fetch).toHaveBeenCalledWith(url, expected);
+  // });
+
+  it ('should post a new project', () => {
+    const url = `${baseUrl}/api/v1/projects/1`;
+
+    createNewPalette(url)
+    .then(results => expect(results).toEqual(mockResponse.id))
+  });
+
+  it('should return an error with unsuccessful post', () => {
+    window.fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: false,
+        statusText: "Error. Please try again."
+      })
+    });
+
+    const url = `${baseUrl}/api/v1/projects`;
+
+    expect(createNewPalette(url)).rejects.toEqual(Error("Error. Please try again."));
+  });
+})
 
 
 // A SINGLE PROJECT

--- a/src/utils/apiCalls/apiCalls.test.js
+++ b/src/utils/apiCalls/apiCalls.test.js
@@ -1,11 +1,14 @@
 import {
   getAllProjects,
+  getAllPalettes,
   getProject,
   getPalettesInProject,
   getPalette,
   createNewProject,
   createNewPalette
 } from './apiCalls';
+
+const baseUrl = 'https://vr-je-palette-picker-api.herokuapp.com'
 
 describe('getAllProjects', () => {
   const mockResponse = [
@@ -22,6 +25,7 @@ describe('getAllProjects', () => {
       updated_at: '2019-12-06T20:35:56.736Z'
     }
   ];
+
   beforeEach(() => {
     window.fetch = jest.fn().mockImplementation(() => {
       return Promise.resolve({
@@ -29,5 +33,65 @@ describe('getAllProjects', () => {
         json: () => Promise.resolve(mockResponse)
       });
     });
+  });
+
+  it ('should fetch with the correct url', () => {
+    const url = `${baseUrl}/api/v1/projects`;
+    getAllProjects(url);
+
+    expect(window.fetch).toHaveBeenCalledWith(url);
+  });
+});
+
+
+// ALL PALETTES
+describe('getAllPalettes', () => {
+  const mockResponse = [
+    {
+        id: 1,
+        palette_name: 'Option 1',
+        color_1: '#192435',
+        color_2: '#678589',
+        color_3: '#77ACA2',
+        color_4: '#EDF3F3',
+        color_5: '#C59563',
+        project_id: 1
+    },
+    {
+        id: 2,
+        palette_name: 'Option 2',
+        color_1: '#D8E2DC',
+        color_2: '#FFE5D9',
+        color_3: '#D1A6AE',
+        color_4: '#9D8189',
+        color_5: '#432F32',
+        project_id: 1
+    },
+    {
+        id: 3,
+        palette_name: 'Ocean',
+        color_1: '#020216',
+        color_2: '#00042B',
+        color_3: '#001E64',
+        color_4: '#006CAD',
+        color_5: '#00C0FA',
+        project_id: 2
+    }
+  ]
+
+  beforeEach(() => {
+    window.fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockResponse)
+      });
+    });
+  });
+
+  it ('should fetch with the correct url', () => {
+    const url = `${baseUrl}/api/v1/palettes`;
+    getAllPalettes(url);
+
+    expect(window.fetch).toHaveBeenCalledWith(url);
   });
 });

--- a/src/utils/apiCalls/apiCalls.test.js
+++ b/src/utils/apiCalls/apiCalls.test.js
@@ -37,6 +37,7 @@ describe('getAllProjects', () => {
 
   it ('should fetch with the correct url', () => {
     const url = `${baseUrl}/api/v1/projects`;
+    
     getAllProjects(url);
 
     expect(window.fetch).toHaveBeenCalledWith(url);
@@ -90,8 +91,72 @@ describe('getAllPalettes', () => {
 
   it ('should fetch with the correct url', () => {
     const url = `${baseUrl}/api/v1/palettes`;
+    
     getAllPalettes(url);
 
     expect(window.fetch).toHaveBeenCalledWith(url);
   });
 });
+
+describe('createNewProject', () => {
+  const mockResponse = { id: 7}
+
+  beforeEach(() => {
+    window.fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockResponse.id)
+      });
+    });
+  });
+  
+  it ('should fetch with correct arguments', () => {
+    const newProject = { project_name: 'New Project' };
+  
+    const url = `${baseUrl}/api/v1/projects`;
+
+    const expected = {
+      method: 'POST',
+      body: JSON.stringify(newProject),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+
+    createNewProject(newProject)
+
+    expect(window.fetch).toHaveBeenCalledWith(url, expected);
+  });
+
+});
+
+
+// A SINGLE PROJECT
+// describe('getProject', () => {
+//   const mockResponse = {
+//       id: 2,
+//       project_name: 'Nature',
+//       created_at: '2019-12-06T20:35:56.736Z',
+//       updated_at: '2019-12-06T20:35:56.736Z'
+//     }
+
+//   beforeEach(() => {
+//     window.fetch = jest.fn().mockImplementation(() => {
+//       return Promise.resolve({
+//         ok: true,
+//         json: () => Promise.resolve(mockResponse)
+//       });
+//     });
+//   });
+
+//   it ('should fetch with the correct url', () => {
+//     window.fetch.mockClear();
+//     const url = `${baseUrl}/api/v1/projects${mockResponse.id}`;
+    
+//     getProject(url);
+
+//     expect(window.fetch).toHaveBeenCalledWith(url);
+//   });
+// });
+
+


### PR DESCRIPTION
## What does this PR do?
Adds tests to the `app.test.js` file

### Where should the reviewer start?
`app.test.js` file

#### How should this be manually tested?
Run `$ npm test`. All tests tests in the `app.test.js` file are passing.

#### Any background context you want to provide?
Tests to still be completed:

- getPalette (happy & sad)
- maybe more for the tests testing the deletes. When running test coverage that area of the `apiCalls.js` file is still showing up under "Uncovered Line #s"
- There is one snapshot still failing due to randomize hexcodes
- still need testing for the `helpers.js` file.

#### What are the relevant tickets?
#28 

#### Screenshots (if appropriate)
<img width="1084" alt="Screen Shot 2019-12-11 at 12 02 40 PM" src="https://user-images.githubusercontent.com/48900496/70651490-28ed9480-1c0e-11ea-93f7-af5c2346e0fe.png">

#### Additional notes

